### PR TITLE
Update live website link to Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A responsive, modern CV / portfolio site built with Next.js, featuring dark/ligh
 
 ## 🌟 Live Website
 
-[View Website ](https://cv-mykhailo-khimich.netlify.app)
+[View Website ](https://cv-personal-hazel.vercel.app/)
 
 ## ✨ Features
 


### PR DESCRIPTION
Points the README "Live Website" link at the current Vercel deployment (https://cv-personal-hazel.vercel.app/) instead of the retired Netlify URL.

## Summary by Sourcery

Documentation:
- Update the README Live Website link to reference the new Vercel-hosted deployment instead of the old Netlify URL.